### PR TITLE
Fixes double dash in Slicer XML from CLI modules

### DIFF
--- a/src/grunt/slicer.go
+++ b/src/grunt/slicer.go
@@ -90,9 +90,13 @@ func CreateServiceFromXML(path string, out string) (*Service, error) {
 				}
 				f := ""
 				if p.Longflag != "" {
+					// Sometimes, the "--" is left on long flags...
+					p.Longflag = strings.TrimPrefix(p.Longflag, "--")
 					f = "--" + p.Longflag
 				}
 				if p.Flag != "" {
+					// Sometimes, the "-" is left on flags...
+					p.Flag = strings.TrimPrefix(p.Flag, "-")
 					f = "-" + p.Flag
 				}
 				if p.Default != "" {


### PR DESCRIPTION
At least one of the CLI modules (MedianImageFilter) reports
`--neighborhood` as the long flag, but it should be without the `--`.
Strip these dashes.